### PR TITLE
fix: call execute_url() in show-item and search-items tools

### DIFF
--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -530,16 +530,13 @@ def show_item(
             if not launch_things():
                 return "Error: Unable to launch Things app"
                 
-        # Execute the show URL command
-        result = show(
-            id=id,
-            query=query,
-            filter_tags=filter_tags
-        )
-        
+        # Build and execute the show URL
+        url = show(id=id, query=query, filter_tags=filter_tags)
+        result = execute_url(url)
+
         if not result:
             return f"Error: Failed to show item/list '{id}'"
-            
+
         return f"Successfully opened '{id}' in Things"
     except Exception as e:
         logger.error(f"Error showing item: {str(e)}")
@@ -559,12 +556,13 @@ def search_all_items(query: str) -> str:
             if not launch_things():
                 return "Error: Unable to launch Things app"
                 
-        # Execute the search URL command
-        result = search(query=query)
-        
+        # Build and execute the search URL
+        url = search(query=query)
+        result = execute_url(url)
+
         if not result:
             return f"Error: Failed to search for '{query}'"
-            
+
         return f"Successfully searched for '{query}' in Things"
     except Exception as e:
         logger.error(f"Error searching: {str(e)}")


### PR DESCRIPTION
## Problem

`show-item` and `search-items` tools construct a Things URL via `show()` but never open it. The bug:

```python
# show() returns a URL string — always truthy
result = show(id=id, ...)
if not result:      # never fires
    return "Error: ..."
return result       # returns the URL string to the caller, Things never sees it
```

Both tools built a `things:///show?...` URL and then returned it as a string rather than calling `execute_url()` on it. Things never received the command.

## Fix

```python
url = show(id=id, ...)
result = execute_url(url)   # actually opens the URL in Things
if not result:
    return f"Error: Failed to show item/list '{id}'"
```

Same fix applied to `search-items`.

## Test

1. Create a todo in Things
2. Call `show-item` with its ID
3. Before fix: nothing happens in Things; tool returns the URL string
4. After fix: Things opens and navigates to the item

## Notes

- `execute_url()` uses `webbrowser.open()` which is reliable for `things://` URLs on macOS
- The `show()` function in `url_scheme.py` is correct — this was purely a call-site omission in `fast_server.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal implementation improvements to core execution pathways while maintaining full API compatibility.

---

**Note:** This release contains internal refactoring with no changes to user-facing functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->