### PR TITLE
Fix FastMCP constructor for current mcp versions and remove PyPI install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,39 +32,9 @@ This MCP server unlocks the power of AI for your task management:
 - Detailed item information including checklists
 - Support for nested data (projects within areas, todos within projects)
 
-## Installation Options
+## Installation
 
-There are multiple ways to install and use the Things MCP server:
-
-### Option 1: Install from PyPI (Recommended)
-
-#### Prerequisites
-* Python 3.12+
-* Claude Desktop
-* Things 3 ("Enable Things URLs" must be turned on in Settings -> General)
-* Things Authentication Token (required for URL scheme operations)
-
-#### Installation
-
-```bash
-pip install things-mcp
-```
-
-Or using uv (recommended):
-
-```bash
-uv pip install things-mcp
-```
-
-#### Running
-
-After installation, you can run the server directly:
-
-```bash
-things-mcp
-```
-
-### Option 2: Manual Installation
+### Manual Installation
 
 #### Prerequisites
 * Python 3.12+

--- a/src/things_mcp/fast_server.py
+++ b/src/things_mcp/fast_server.py
@@ -31,9 +31,8 @@ logger = get_logger(__name__)
 
 # Create the FastMCP server
 mcp = FastMCP(
-    "Things", 
-    description="Interact with the Things task management app",
-    version="0.1.1"
+    "Things",
+    instructions="Interact with the Things task management app",
 )
 
 # LIST VIEWS


### PR DESCRIPTION
## Summary

Two related fixes that together get the server running again from a fresh clone:

1. **`FastMCP(...)` constructor crash on startup.** With `mcp >= ~1.10`, `FastMCP.__init__()` no longer accepts `description=` or `version=` kwargs, so the server crashes on import:

   ```
   TypeError: FastMCP.__init__() got an unexpected keyword argument 'description'
   ```

   Replaced with the modern `instructions=` parameter; `version` is now read automatically from the installed `mcp` package metadata.

2. **README points at a PyPI package that doesn't publish this fork.** "Option 1: Install from PyPI" tells users to `pip install things-mcp`, but that name resolves to the upstream `hald/things-mcp` package on PyPI — not this fork — so users following the README either get the wrong code or (per #7) hit a name that doesn't exist at all. Removed Option 1 entirely and promoted "Manual Installation" as the single supported path until/unless this fork is published.

## Test plan

- [x] Fresh clone + `uv venv && uv pip install -e .` + run `things_fast_server.py` — server starts and responds to a JSON-RPC `initialize` request
- [x] Connects successfully as an MCP server in Claude Code
- [x] `get-inbox` and `get-today` tools return data from a live Things 3 install

Closes #7.
